### PR TITLE
Fix default content type

### DIFF
--- a/src/traits/ContentNegotiator.php
+++ b/src/traits/ContentNegotiator.php
@@ -12,10 +12,10 @@ trait ContentNegotiator
     public $requestJson;
     private $negotiatorProcessed = false;
     public $negotiatorFormats = [
+        'text/html' => Response::FORMAT_HTML,
         'application/json' => Response::FORMAT_JSON,
         'text/javascript' => Response::FORMAT_JSONP,
         'text/xml' => Response::FORMAT_XML,
-        'text/html' => Response::FORMAT_HTML,
     ];
 
     /**


### PR DESCRIPTION
If browser doesn't send accept type then server returns the first response format (json). It's wrong.